### PR TITLE
refactor(pyoverlay): use ViamImage instead of PIL.Image

### DIFF
--- a/pyoverlay/.gitignore
+++ b/pyoverlay/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.venv/

--- a/pyoverlay/overlay.py
+++ b/pyoverlay/overlay.py
@@ -5,14 +5,15 @@ from typing_extensions import Self
 from viam.module.types import Reconfigurable
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName, ResponseMetadata, Geometry
-from viam.components.camera import Camera
+from viam.components.camera import Camera, ViamImage
 from viam.resource.types import Model, ModelFamily
 from viam.resource.base import ResourceBase
-from viam.media.video import NamedImage
-from PIL import Image, ImageDraw, ImageFont
-from viam.services.vision import Vision
+from viam.media.video import CameraMimeType, NamedImage
+from viam.media.utils.pil import pil_to_viam_image, viam_to_pil_image
+from PIL import ImageDraw, ImageFont
 
 import time
+
 
 class OverlayCam(Camera, Reconfigurable):
     MODEL: ClassVar[Model] = Model(ModelFamily("viam-labs", "camera"), "overlay-fps")
@@ -21,7 +22,9 @@ class OverlayCam(Camera, Reconfigurable):
         super().__init__(name)
 
     @classmethod
-    def new_cam(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:
+    def new_cam(
+        cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
+    ) -> Self:
         cam = cls(config.name)
         cam.reconfigure(config, dependencies)
         return cam
@@ -31,41 +34,63 @@ class OverlayCam(Camera, Reconfigurable):
         """Validates JSON configuration"""
         actual_cam = config.attributes.fields["camera_name"].string_value
         if actual_cam == "":
-            raise Exception("camera_name attribute is required for a OverlayCam component")
+            raise Exception(
+                "camera_name attribute is required for a OverlayCam component"
+            )
         return [actual_cam]
 
-    def reconfigure(self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]):
+    def reconfigure(
+        self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
+    ):
         """Handles attribute reconfiguration"""
         actual_cam_name = config.attributes.fields["camera_name"].string_value
         actual_cam = dependencies[Camera.get_resource_name(actual_cam_name)]
         self.actual_cam = cast(Camera, actual_cam)
 
-    async def get_properties(self, *, timeout: Optional[float] = None, **kwargs) -> Camera.Properties:
+    async def get_properties(
+        self, *, timeout: Optional[float] = None, **kwargs
+    ) -> Camera.Properties:
         """Returns details about the camera"""
         return await self.actual_cam.get_properties()
 
-    async def get_image(self, mime_type: str = "", *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Image.Image:
+    async def get_image(
+        self,
+        mime_type: str = "",
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs
+    ) -> ViamImage:
         if mime_type == "":
             mime_type = "image/jpeg"
         start_time = time.time()
         img = await self.actual_cam.get_image(mime_type)
+        pil_img = viam_to_pil_image(img)
         end_time = time.time()
         duration = end_time - start_time
         # overlay the fps
-        draw = ImageDraw.Draw(img)
+        draw = ImageDraw.Draw(pil_img)
         font_size = 30
-        #font = ImageFont.load_default()
+        # font = ImageFont.load_default()
         font = ImageFont.truetype("FreeMono.ttf", size=font_size)
         position = (30, 30)
         text_color = (255, 0, 0)
-        formatted_text = "FPS: {:.2f}".format(1./duration)
+        formatted_text = "FPS: {:.2f}".format(1.0 / duration)
         draw.text(position, formatted_text, fill=text_color, font=font)
-        return img
+        return pil_to_viam_image(pil_img, CameraMimeType.from_string(mime_type))
 
-    async def get_images(self, *, timeout: Optional[float] = None, **kwargs) -> Tuple[List[NamedImage], ResponseMetadata]:
+    async def get_images(
+        self, *, timeout: Optional[float] = None, **kwargs
+    ) -> Tuple[List[NamedImage], ResponseMetadata]:
         raise NotImplementedError
 
-    async def get_point_cloud(self, *, extra: Optional[Dict[str, Any]] = None, timeout: Optional[float] = None, **kwargs) -> Tuple[bytes, str]:
+    async def get_point_cloud(
+        self,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+        **kwargs
+    ) -> Tuple[bytes, str]:
         raise NotImplementedError
 
     async def get_geometries(self) -> List[Geometry]:

--- a/pyoverlay/requirements.txt
+++ b/pyoverlay/requirements.txt
@@ -1,2 +1,3 @@
 # add a version if viam should be pinned to a specific version
-viam-sdk
+viam-sdk==v0.21.0
+pillow


### PR DESCRIPTION
To accommodate the latest changes in the Viam Python SDK (https://github.com/viamrobotics/viam-python-sdk/releases), this PR refactors the `pyoverlay` Camera to return a `ViamImage` instead of a Pillow `Image`. 